### PR TITLE
fix: PPTX 图片信息较多时内存溢出，优化文件去重

### DIFF
--- a/src/fill.js
+++ b/src/fill.js
@@ -12,11 +12,9 @@ import {
 } from './color'
 
 import {
-  base64ArrayBuffer,
   getTextByPathList,
   angleToDegrees,
   escapeHtml,
-  getMimeType,
   toHex,
 } from './utils'
 
@@ -59,10 +57,7 @@ export async function getPicFill(type, node, warpObj) {
 
     const imgExt = imgPath.split('.').pop()
     if (imgExt === 'xml') return undefined
-
-    const imgArrayBuffer = await warpObj['zip'].file(imgPath).async('arraybuffer')
-    const imgMimeType = getMimeType(imgExt)
-    img = `data:${imgMimeType};base64,${base64ArrayBuffer(imgArrayBuffer)}`
+    img = await warpObj['zip'].getFileBlobUrl(imgPath)
   }
   return img
 }


### PR DESCRIPTION
当 pptx 文件中图片元素比较时，解析是占用内存会飙升至溢出。

![image](https://github.com/user-attachments/assets/b288bfde-9fb5-4958-99a6-a08409879a43)

定位了下主要是发生在，图片 buffer 转 base64 时，并且文件没有去重处理，导致占用飙升。优化修改成像和音视频一样，返回 blob 链接。

之前文件读取时，当多个页面使用相同元素图片（还挺常见的），在解析时会重复把相同文件转成 base64，也会导致解析速度变慢，增加了下相同文件缓存处理。

ps: 目前优化是直接返回 blob 地址（内存占用比较小），没有测试文件去重但是保留 base64 格式情况。

