### PR TITLE
fix: 备注为空时解析有误的问题

### DIFF
--- a/src/pptxtojson.js
+++ b/src/pptxtojson.js
@@ -307,7 +307,7 @@ function getNote(noteContent) {
     if (rNodes.constructor !== Array) rNodes = [rNodes]
     for (const rNode of rNodes) {
       const t = getTextByPathList(rNode, ['a:t'])
-      if (t) text += t
+      if (t && typeof t === "string") text += t
     }
   }
   return text


### PR DESCRIPTION
修复了备注为空时，会解析成 `"[object Object]"` 的问题

![image](https://github.com/user-attachments/assets/b71fa3c7-f8e5-407c-9b3d-03f548b52366)
