### PR TITLE
fix: add .js extensions to ES module imports

### DIFF
--- a/src/align.js
+++ b/src/align.js
@@ -1,4 +1,4 @@
-import { getTextByPathList } from './utils'
+import { getTextByPathList } from './utils.js'
 
 export function getHorizontalAlign(node, pNode, type, warpObj) {
   let algn = getTextByPathList(node, ['a:pPr', 'attrs', 'algn'])
@@ -18,10 +18,10 @@ export function getHorizontalAlign(node, pNode, type, warpObj) {
       if (!algn && type === 'subTitle') {
         algn = getTextByPathList(warpObj, ['slideMasterTextStyles', 'p:bodyStyle', lvlStr, 'attrs', 'algn'])
       }
-    } 
+    }
     else if (type === 'body') {
       algn = getTextByPathList(warpObj, ['slideMasterTextStyles', 'p:bodyStyle', 'a:lvl1pPr', 'attrs', 'algn'])
-    } 
+    }
     else {
       algn = getTextByPathList(warpObj, ['slideMasterTables', 'typeTable', type, 'p:txBody', 'a:lstStyle', 'a:lvl1pPr', 'attrs', 'algn'])
     }

--- a/src/border.js
+++ b/src/border.js
@@ -1,6 +1,6 @@
 import tinycolor from 'tinycolor2'
-import { getSchemeColorFromTheme } from './schemeColor'
-import { getTextByPathList } from './utils'
+import { getSchemeColorFromTheme } from './schemeColor.js'
+import { getTextByPathList } from './utils.js'
 
 export function getBorder(node, elType, warpObj) {
   let lineNode = getTextByPathList(node, ['p:spPr', 'a:ln'])
@@ -39,7 +39,7 @@ export function getBorder(node, elType, warpObj) {
 
       if (shade) {
         shade = parseInt(shade) / 100000
-        
+
         const color = tinycolor('#' + borderColor).toHsl()
         borderColor = tinycolor({ h: color.h, s: color.s, l: color.l * shade, a: color.a }).toHex()
       }

--- a/src/chart.js
+++ b/src/chart.js
@@ -1,5 +1,5 @@
-import { eachElement, getTextByPathList } from './utils'
-import { applyTint } from './color'
+import { eachElement, getTextByPathList } from './utils.js'
+import { applyTint } from './color.js'
 
 function extractChartColors(serNode, warpObj) {
   if (serNode.constructor !== Array) serNode = [serNode]
@@ -42,7 +42,7 @@ function extractChartData(serNode) {
       return ''
     })
     dataMat.push(dataRow)
-  } 
+  }
   else {
     eachElement(serNode, (innerNode, index) => {
       const dataRow = []
@@ -54,7 +54,7 @@ function extractChartData(serNode) {
           rowNames[innerNode['attrs']['idx']] = innerNode['c:v']
           return ''
         })
-      } 
+      }
       else if (getTextByPathList(innerNode, ['c:cat', 'c:numRef', 'c:numCache', 'c:pt'])) {
         eachElement(innerNode['c:cat']['c:numRef']['c:numCache']['c:pt'], innerNode => {
           rowNames[innerNode['attrs']['idx']] = innerNode['c:v']

--- a/src/fill.js
+++ b/src/fill.js
@@ -1,5 +1,5 @@
 import tinycolor from 'tinycolor2'
-import { getSchemeColorFromTheme } from './schemeColor'
+import { getSchemeColorFromTheme } from './schemeColor.js'
 import {
   applyShade,
   applyTint,
@@ -9,7 +9,7 @@ import {
   applySatMod,
   hslToRgb,
   getColorName2Hex,
-} from './color'
+} from './color.js'
 
 import {
   base64ArrayBuffer,
@@ -18,7 +18,7 @@ import {
   escapeHtml,
   getMimeType,
   toHex,
-} from './utils'
+} from './utils.js'
 
 export function getFillType(node) {
   let fillType = ''
@@ -105,7 +105,7 @@ export function getGradientFill(node, warpObj) {
   for (let i = 0; i < gsLst.length; i++) {
     const lo_color = getSolidFill(gsLst[i], undefined, undefined, warpObj)
     const pos = getTextByPathList(gsLst[i], ['attrs', 'pos'])
-    
+
     colors[i] = {
       pos: pos ? (pos / 1000 + '%') : '',
       color: lo_color,
@@ -117,7 +117,7 @@ export function getGradientFill(node, warpObj) {
   if (lin) rot = angleToDegrees(lin['attrs']['ang'])
   else {
     const path = node['a:path']
-    if (path && path['attrs'] && path['attrs']['path']) pathType = path['attrs']['path'] 
+    if (path && path['attrs'] && path['attrs']['path']) pathType = path['attrs']['path']
   }
   return {
     rot,
@@ -131,7 +131,7 @@ export function getBgGradientFill(bgPr, phClr, slideMasterContent, warpObj) {
     const grdFill = bgPr['a:gradFill']
     const gsLst = grdFill['a:gsLst']['a:gs']
     const colors = []
-    
+
     for (let i = 0; i < gsLst.length; i++) {
       const lo_color = getSolidFill(gsLst[i], slideMasterContent['p:sldMaster']['p:clrMap']['attrs'], phClr, warpObj)
       const pos = getTextByPathList(gsLst[i], ['attrs', 'pos'])
@@ -147,7 +147,7 @@ export function getBgGradientFill(bgPr, phClr, slideMasterContent, warpObj) {
     if (lin) rot = angleToDegrees(lin['attrs']['ang']) + 0
     else {
       const path = grdFill['a:path']
-      if (path && path['attrs'] && path['attrs']['path']) pathType = path['attrs']['path'] 
+      if (path && path['attrs'] && path['attrs']['path']) pathType = path['attrs']['path']
     }
     return {
       rot,
@@ -165,7 +165,7 @@ export async function getSlideBackgroundFill(warpObj) {
   const slideContent = warpObj['slideContent']
   const slideLayoutContent = warpObj['slideLayoutContent']
   const slideMasterContent = warpObj['slideMasterContent']
-  
+
   let bgPr = getTextByPathList(slideContent, ['p:sld', 'p:cSld', 'p:bg', 'p:bgPr'])
   let bgRef = getTextByPathList(slideContent, ['p:sld', 'p:cSld', 'p:bg', 'p:bgRef'])
 
@@ -234,7 +234,7 @@ export async function getSlideBackgroundFill(warpObj) {
               }
               sortblAry.push(obj)
             }
-          } 
+          }
           else {
             const obj = {}
             obj[key] = bgFillLstTyp
@@ -256,7 +256,7 @@ export async function getSlideBackgroundFill(warpObj) {
         const sldFill = bgFillLstIdx['a:solidFill']
         const sldBgClr = getSolidFill(sldFill, clrMapOvr, undefined, warpObj)
         background = sldBgClr
-      } 
+      }
       else if (bgFillTyp === 'GRADIENT_FILL') {
         const gradientFill = getBgGradientFill(bgFillLstIdx, phClr, slideMasterContent, warpObj)
         if (typeof gradientFill === 'string') {
@@ -303,7 +303,7 @@ export async function getSlideBackgroundFill(warpObj) {
     else if (bgRef) {
       const phClr = getSolidFill(bgRef, clrMapOvr, undefined, warpObj)
       const idx = Number(bgRef['attrs']['idx'])
-  
+
       if (idx > 1000) {
         const trueIdx = idx - 1000
         const bgFillLst = warpObj['themeContent']['a:theme']['a:themeElements']['a:fmtScheme']['a:bgFillStyleLst']
@@ -323,7 +323,7 @@ export async function getSlideBackgroundFill(warpObj) {
                 }
                 sortblAry.push(obj)
               }
-            } 
+            }
             else {
               const obj = {}
               obj[key] = bgFillLstTyp
@@ -345,7 +345,7 @@ export async function getSlideBackgroundFill(warpObj) {
           const sldFill = bgFillLstIdx['a:solidFill']
           const sldBgClr = getSolidFill(sldFill, clrMapOvr, undefined, warpObj)
           background = sldBgClr
-        } 
+        }
         else if (bgFillTyp === 'GRADIENT_FILL') {
           const gradientFill = getBgGradientFill(bgFillLstIdx, phClr, slideMasterContent, warpObj)
           if (typeof gradientFill === 'string') {
@@ -392,7 +392,7 @@ export async function getSlideBackgroundFill(warpObj) {
       else if (bgRef) {
         const phClr = getSolidFill(bgRef, clrMap, undefined, warpObj)
         const idx = Number(bgRef['attrs']['idx'])
-    
+
         if (idx > 1000) {
           const trueIdx = idx - 1000
           const bgFillLst = warpObj['themeContent']['a:theme']['a:themeElements']['a:fmtScheme']['a:bgFillStyleLst']
@@ -412,7 +412,7 @@ export async function getSlideBackgroundFill(warpObj) {
                   }
                   sortblAry.push(obj)
                 }
-              } 
+              }
               else {
                 const obj = {}
                 obj[key] = bgFillLstTyp
@@ -434,7 +434,7 @@ export async function getSlideBackgroundFill(warpObj) {
             const sldFill = bgFillLstIdx['a:solidFill']
             const sldBgClr = getSolidFill(sldFill, clrMapOvr, undefined, warpObj)
             background = sldBgClr
-          } 
+          }
           else if (bgFillTyp === 'GRADIENT_FILL') {
             const gradientFill = getBgGradientFill(bgFillLstIdx, phClr, slideMasterContent, warpObj)
             if (typeof gradientFill === 'string') {
@@ -465,7 +465,7 @@ export async function getShapeFill(node, pNode, isSvgMode, warpObj, source) {
   let fillValue = ''
   if (fillType === 'NO_FILL') {
     return isSvgMode ? 'none' : ''
-  } 
+  }
   else if (fillType === 'SOLID_FILL') {
     const shpFill = node['p:spPr']['a:solidFill']
     fillValue = getSolidFill(shpFill, undefined, undefined, warpObj)
@@ -499,7 +499,7 @@ export async function getShapeFill(node, pNode, isSvgMode, warpObj, source) {
         const spShpNode = { 'p:spPr': grpShpFill }
         return getShapeFill(spShpNode, node, isSvgMode, warpObj, source)
       }
-    } 
+    }
     else if (fillType === 'NO_FILL') {
       return isSvgMode ? 'none' : ''
     }
@@ -520,7 +520,7 @@ export function getSolidFill(solidFill, clrMap, phClr, warpObj) {
   if (solidFill['a:srgbClr']) {
     clrNode = solidFill['a:srgbClr']
     color = getTextByPathList(clrNode, ['attrs', 'val'])
-  } 
+  }
   else if (solidFill['a:schemeClr']) {
     clrNode = solidFill['a:schemeClr']
     const schemeClr = 'a:' + getTextByPathList(clrNode, ['attrs', 'val'])
@@ -533,12 +533,12 @@ export function getSolidFill(solidFill, clrMap, phClr, warpObj) {
     const green = (defBultColorVals['g'].indexOf('%') !== -1) ? defBultColorVals['g'].split('%').shift() : defBultColorVals['g']
     const blue = (defBultColorVals['b'].indexOf('%') !== -1) ? defBultColorVals['b'].split('%').shift() : defBultColorVals['b']
     color = toHex(255 * (Number(red) / 100)) + toHex(255 * (Number(green) / 100)) + toHex(255 * (Number(blue) / 100))
-  } 
+  }
   else if (solidFill['a:prstClr']) {
     clrNode = solidFill['a:prstClr']
     const prstClr = getTextByPathList(clrNode, ['attrs', 'val'])
     color = getColorName2Hex(prstClr)
-  } 
+  }
   else if (solidFill['a:hslClr']) {
     clrNode = solidFill['a:hslClr']
     const defBultColorVals = clrNode['attrs']
@@ -547,7 +547,7 @@ export function getSolidFill(solidFill, clrMap, phClr, warpObj) {
     const lum = Number((defBultColorVals['lum'].indexOf('%') !== -1) ? defBultColorVals['lum'].split('%').shift() : defBultColorVals['lum']) / 100
     const hsl2rgb = hslToRgb(hue, sat, lum)
     color = toHex(hsl2rgb.r) + toHex(hsl2rgb.g) + toHex(hsl2rgb.b)
-  } 
+  }
   else if (solidFill['a:sysClr']) {
     clrNode = solidFill['a:sysClr']
     const sysClr = getTextByPathList(clrNode, ['attrs', 'lastClr'])

--- a/src/fontStyle.js
+++ b/src/fontStyle.js
@@ -1,6 +1,6 @@
-import { getTextByPathList } from './utils'
-import { getShadow } from './shadow'
-import { getFillType, getSolidFill } from './fill'
+import { getTextByPathList } from './utils.js'
+import { getShadow } from './shadow.js'
+import { getFillType, getSolidFill } from './fill.js'
 
 export function getFontType(node, type, warpObj) {
   let typeface = getTextByPathList(node, ['a:rPr', 'a:latin', 'attrs', 'typeface'])
@@ -10,10 +10,10 @@ export function getFontType(node, type, warpObj) {
 
     if (type === 'title' || type === 'subTitle' || type === 'ctrTitle') {
       typeface = getTextByPathList(fontSchemeNode, ['a:majorFont', 'a:latin', 'attrs', 'typeface'])
-    } 
+    }
     else if (type === 'body') {
       typeface = getTextByPathList(fontSchemeNode, ['a:minorFont', 'a:latin', 'attrs', 'typeface'])
-    } 
+    }
     else {
       typeface = getTextByPathList(fontSchemeNode, ['a:minorFont', 'a:latin', 'attrs', 'typeface'])
     }
@@ -62,13 +62,13 @@ export function getFontSize(node, slideLayoutSpNode, type, slideMasterTextStyles
     let sz
     if (type === 'title' || type === 'subTitle' || type === 'ctrTitle') {
       sz = getTextByPathList(slideMasterTextStyles, ['p:titleStyle', 'a:lvl1pPr', 'a:defRPr', 'attrs', 'sz'])
-    } 
+    }
     else if (type === 'body') {
       sz = getTextByPathList(slideMasterTextStyles, ['p:bodyStyle', 'a:lvl1pPr', 'a:defRPr', 'attrs', 'sz'])
-    } 
+    }
     else if (type === 'dt' || type === 'sldNum') {
       sz = '1200'
-    } 
+    }
     else if (!type) {
       sz = getTextByPathList(slideMasterTextStyles, ['p:otherStyle', 'a:lvl1pPr', 'a:defRPr', 'attrs', 'sz'])
     }

--- a/src/math.js
+++ b/src/math.js
@@ -1,10 +1,10 @@
-import { getTextByPathList } from './utils'
+import { getTextByPathList } from './utils.js'
 
 export function findOMath(obj) {
   let results = []
   if (typeof obj !== 'object') return results
   if (obj['m:oMath']) results = results.concat(obj['m:oMath'])
-  
+
   Object.values(obj).forEach(value => {
     if (Array.isArray(value) || typeof value === 'object') {
       results = results.concat(findOMath(value))

--- a/src/position.js
+++ b/src/position.js
@@ -1,4 +1,4 @@
-import { RATIO_EMUs_Points } from './constants'
+import { RATIO_EMUs_Points } from './constants.js'
 
 export function getPosition(slideSpNode, slideLayoutSpNode, slideMasterSpNode) {
   let off

--- a/src/pptxtojson.js
+++ b/src/pptxtojson.js
@@ -1,22 +1,22 @@
 import JSZip from 'jszip'
-import { readXmlFile } from './readXmlFile'
-import { getBorder } from './border'
-import { getSlideBackgroundFill, getShapeFill, getSolidFill, getPicFill } from './fill'
-import { getChartInfo } from './chart'
-import { getVerticalAlign } from './align'
-import { getPosition, getSize } from './position'
-import { genTextBody } from './text'
-import { getCustomShapePath } from './shape'
-import { extractFileExtension, base64ArrayBuffer, getTextByPathList, angleToDegrees, getMimeType, isVideoLink, escapeHtml, hasValidText } from './utils'
-import { getShadow } from './shadow'
-import { getTableBorders, getTableCellParams, getTableRowParams } from './table'
-import { RATIO_EMUs_Points } from './constants'
-import { findOMath, latexFormart, parseOMath } from './math'
-import { getShapePath } from './shapePath'
+import { readXmlFile } from './readXmlFile.js'
+import { getBorder } from './border.js'
+import { getSlideBackgroundFill, getShapeFill, getSolidFill, getPicFill } from './fill.js'
+import { getChartInfo } from './chart.js'
+import { getVerticalAlign } from './align.js'
+import { getPosition, getSize } from './position.js'
+import { genTextBody } from './text.js'
+import { getCustomShapePath } from './shape.js'
+import { extractFileExtension, base64ArrayBuffer, getTextByPathList, angleToDegrees, getMimeType, isVideoLink, escapeHtml, hasValidText } from './utils.js'
+import { getShadow } from './shadow.js'
+import { getTableBorders, getTableCellParams, getTableRowParams } from './table.js'
+import { RATIO_EMUs_Points } from './constants.js'
+import { findOMath, latexFormart, parseOMath } from './math.js'
+import { getShapePath } from './shapePath.js'
 
 export async function parse(file) {
   const slides = []
-  
+
   const zip = await JSZip.loadAsync(file)
 
   const filesInfo = await getContentTypes(zip)
@@ -55,7 +55,7 @@ async function getContentTypes(zip) {
       default:
     }
   }
-  
+
   const sortSlideXml = (p1, p2) => {
     const n1 = +/(\d+)\.xml/.exec(p1)[1]
     const n2 = +/(\d+)\.xml/.exec(p2)[1]
@@ -63,7 +63,7 @@ async function getContentTypes(zip) {
   }
   slidesLocArray = slidesLocArray.sort(sortSlideXml)
   slideLayoutsLocArray = slideLayoutsLocArray.sort(sortSlideXml)
-  
+
   return {
     slides: slidesLocArray,
     slideLayouts: slideLayoutsLocArray,
@@ -93,7 +93,7 @@ async function getTheme(zip) {
         break
       }
     }
-  } 
+  }
   else if (relationshipArray['attrs']['Type'] === 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme') {
     themeURI = relationshipArray['attrs']['Target']
   }
@@ -118,7 +118,7 @@ async function processSingleSlide(zip, sldFileName, themeContent, defaultTextSty
   const resContent = await readXmlFile(zip, resName)
   let relationshipArray = resContent['Relationships']['Relationship']
   if (relationshipArray.constructor !== Array) relationshipArray = [relationshipArray]
-  
+
   let noteFilename = ''
   let layoutFilename = ''
   let masterFilename = ''
@@ -155,7 +155,7 @@ async function processSingleSlide(zip, sldFileName, themeContent, defaultTextSty
         }
     }
   }
-  
+
   const slideNotesContent = await readXmlFile(zip, noteFilename)
   const note = getNote(slideNotesContent)
 
@@ -319,7 +319,7 @@ async function getLayoutElements(warpObj) {
             if (ret) elements.push(ret)
           }
         }
-      } 
+      }
       else {
         const ph = getTextByPathList(nodesSldLayout[nodeKey], ['p:nvSpPr', 'p:nvPr', 'p:ph'])
         if (!ph) {
@@ -339,7 +339,7 @@ async function getLayoutElements(warpObj) {
             if (ret) elements.push(ret)
           }
         }
-      } 
+      }
       else {
         const ph = getTextByPathList(nodesSldMaster[nodeKey], ['p:nvSpPr', 'p:nvPr', 'p:ph'])
         if (!ph) {
@@ -375,7 +375,7 @@ function indexNodes(content) {
         if (idx) idxTable[idx] = targetNodeItem
         if (type) typeTable[type] = targetNodeItem
       }
-    } 
+    }
     else {
       const nvSpPrNode = targetNode['p:nvSpPr']
       const id = getTextByPathList(nvSpPrNode, ['p:cNvPr', 'attrs', 'id'])
@@ -449,7 +449,7 @@ async function processMathNode(node, warpObj, source) {
     type: 'math',
     top,
     left,
-    width, 
+    width,
     height,
     latex,
     picBase64,
@@ -527,7 +527,7 @@ async function processSpNode(node, pNode, warpObj, source) {
     if (idx) {
       slideLayoutSpNode = warpObj['slideLayoutTables']['typeTable'][type]
       slideMasterSpNode = warpObj['slideMasterTables']['typeTable'][type]
-    } 
+    }
     else {
       slideLayoutSpNode = warpObj['slideLayoutTables']['typeTable'][type]
       slideMasterSpNode = warpObj['slideMasterTables']['typeTable'][type]
@@ -583,7 +583,7 @@ async function genShape(node, pNode, slideLayoutSpNode, slideMasterSpNode, name,
   if (txtXframeNode) {
     const txtXframeRot = getTextByPathList(txtXframeNode, ['attrs', 'rot'])
     if (txtXframeRot) txtRotate = angleToDegrees(txtXframeRot) + 90
-  } 
+  }
   else txtRotate = rotate
 
   let content = ''
@@ -673,7 +673,7 @@ async function processPicNode(node, warpObj, source) {
   else resObj = warpObj['slideResObj']
 
   const order = node['attrs']['order']
-  
+
   const rid = node['p:blipFill']['a:blip']['attrs']['r:embed']
   const imgName = resObj[rid]['target']
   const imgFileExt = extractFileExtension(imgName).toLowerCase()
@@ -708,7 +708,7 @@ async function processPicNode(node, warpObj, source) {
     if (isVideoLink(videoFile)) {
       videoFile = escapeHtml(videoFile)
       isVdeoLink = true
-    } 
+    }
     else {
       videoFileExt = extractFileExtension(videoFile).toLowerCase()
       if (videoFileExt === 'mp4' || videoFileExt === 'webm' || videoFileExt === 'ogg') {
@@ -738,19 +738,19 @@ async function processPicNode(node, warpObj, source) {
       type: 'video',
       top,
       left,
-      width, 
+      width,
       height,
       rotate,
       blob: videoBlob,
       order,
     }
-  } 
+  }
   if (videoNode && isVdeoLink) {
     return {
       type: 'video',
       top,
       left,
-      width, 
+      width,
       height,
       rotate,
       src: videoFile,
@@ -762,7 +762,7 @@ async function processPicNode(node, warpObj, source) {
       type: 'audio',
       top,
       left,
-      width, 
+      width,
       height,
       rotate,
       blob: audioBlob,
@@ -787,7 +787,7 @@ async function processPicNode(node, warpObj, source) {
     type: 'image',
     top,
     left,
-    width, 
+    width,
     height,
     rotate,
     src,
@@ -805,7 +805,7 @@ async function processPicNode(node, warpObj, source) {
 
 async function processGraphicFrameNode(node, warpObj, source) {
   const graphicTypeUri = getTextByPathList(node, ['a:graphic', 'a:graphicData', 'attrs', 'uri'])
-  
+
   let result
   switch (graphicTypeUri) {
     case 'http://schemas.openxmlformats.org/drawingml/2006/table':
@@ -873,7 +873,7 @@ async function genTable(node, warpObj) {
             thisTblStyle = tbleStylList[k]
           }
         }
-      } 
+      }
       else {
         if (tbleStylList['attrs']['styleId'] === tbleStyleId) {
           thisTblStyle = tbleStylList
@@ -900,12 +900,12 @@ async function genTable(node, warpObj) {
 
   let trNodes = tableNode['a:tr']
   if (trNodes.constructor !== Array) trNodes = [trNodes]
-  
+
   const data = []
   const rowHeights = []
   for (let i = 0; i < trNodes.length; i++) {
     const trNode = trNodes[i]
-    
+
     const rowHeightParam = getTextByPathList(trNodes[i], ['attrs', 'h']) || 0
     const rowHeight = parseInt(rowHeightParam) * RATIO_EMUs_Points
     rowHeights.push(rowHeight)
@@ -927,12 +927,12 @@ async function genTable(node, warpObj) {
           a_sorce = 'a:firstCol'
           if (tblStylAttrObj['isLstRowAttr'] === 1 && i === (trNodes.length - 1) && getTextByPathList(thisTblStyle, ['a:seCell'])) {
             a_sorce = 'a:seCell'
-          } 
+          }
           else if (tblStylAttrObj['isFrstRowAttr'] === 1 && i === 0 &&
             getTextByPathList(thisTblStyle, ['a:neCell'])) {
             a_sorce = 'a:neCell'
           }
-        } 
+        }
         else if (
           (j > 0 && tblStylAttrObj['isBandColAttr'] === 1) &&
           !(tblStylAttrObj['isFrstColAttr'] === 1 && i === 0) &&
@@ -944,7 +944,7 @@ async function genTable(node, warpObj) {
             if (aBandNode === undefined) {
               aBandNode = getTextByPathList(thisTblStyle, ['a:band1V'])
               if (aBandNode) a_sorce = 'a:band2V'
-            } 
+            }
             else a_sorce = 'a:band2V'
           }
         }
@@ -952,7 +952,7 @@ async function genTable(node, warpObj) {
           a_sorce = 'a:lastCol'
           if (tblStylAttrObj['isLstRowAttr'] === 1 && i === (trNodes.length - 1) && getTextByPathList(thisTblStyle, ['a:swCell'])) {
             a_sorce = 'a:swCell'
-          } 
+          }
           else if (tblStylAttrObj['isFrstRowAttr'] === 1 && i === 0 && getTextByPathList(thisTblStyle, ['a:nwCell'])) {
             a_sorce = 'a:nwCell'
           }
@@ -971,18 +971,18 @@ async function genTable(node, warpObj) {
 
         tr.push(td)
       }
-    } 
+    }
     else {
       let a_sorce
       if (tblStylAttrObj['isFrstColAttr'] === 1 && tblStylAttrObj['isLstRowAttr'] !== 1) {
         a_sorce = 'a:firstCol'
-      } 
+      }
       else if (tblStylAttrObj['isBandColAttr'] === 1 && tblStylAttrObj['isLstRowAttr'] !== 1) {
         let aBandNode = getTextByPathList(thisTblStyle, ['a:band2V'])
         if (!aBandNode) {
           aBandNode = getTextByPathList(thisTblStyle, ['a:band1V'])
           if (aBandNode) a_sorce = 'a:band2V'
-        } 
+        }
         else a_sorce = 'a:band2V'
       }
       if (tblStylAttrObj['isLstColAttr'] === 1 && tblStylAttrObj['isLstRowAttr'] !== 1) {
@@ -1064,7 +1064,7 @@ async function genDiagram(node, warpObj) {
   const xfrmNode = getTextByPathList(node, ['p:xfrm'])
   const { left, top } = getPosition(xfrmNode, undefined, undefined)
   const { width, height } = getSize(xfrmNode, undefined, undefined)
-  
+
   const dgmDrwSpArray = getTextByPathList(warpObj['digramFileContent'], ['p:drawing', 'p:spTree', 'p:sp'])
   const elements = []
   if (dgmDrwSpArray) {

--- a/src/schemeColor.js
+++ b/src/schemeColor.js
@@ -1,4 +1,4 @@
-import { getTextByPathList } from './utils'
+import { getTextByPathList } from './utils.js'
 
 export function getSchemeColorFromTheme(schemeClr, warpObj, clrMap, phClr) {
   let color

--- a/src/shadow.js
+++ b/src/shadow.js
@@ -1,5 +1,5 @@
-import { getSolidFill } from './fill'
-import { RATIO_EMUs_Points } from './constants'
+import { getSolidFill } from './fill.js'
+import { RATIO_EMUs_Points } from './constants.js'
 
 export function getShadow(node, warpObj) {
   const chdwClrNode = getSolidFill(node, undefined, undefined, warpObj)

--- a/src/shape.js
+++ b/src/shape.js
@@ -1,4 +1,4 @@
-import { getTextByPathList } from './utils'
+import { getTextByPathList } from './utils.js'
 
 export function shapeArc(cX, cY, rX, rY, stAng, endAng, isClose) {
   let dData
@@ -14,7 +14,7 @@ export function shapeArc(cX, cY, rX, rY, stAng, endAng, isClose) {
       dData += ' L' + x + ' ' + y
       angle++
     }
-  } 
+  }
   else {
     while (angle > endAng) {
       const radians = angle * (Math.PI / 180)
@@ -158,12 +158,12 @@ export function getCustomShapePath(custShapType, w, h) {
         const spX = parseInt(multiSapeAry[k].x) * cX
         const spY = parseInt(multiSapeAry[k].y) * cY
         d += ' M' + spX + ',' + spY
-      } 
+      }
       else if (multiSapeAry[k].type === 'lnto') {
         const Lx = parseInt(multiSapeAry[k].x) * cX
         const Ly = parseInt(multiSapeAry[k].y) * cY
         d += ' L' + Lx + ',' + Ly
-      } 
+      }
       else if (multiSapeAry[k].type === 'cubicBezTo') {
         const Cx1 = parseInt(multiSapeAry[k].cubBzPt[0].x) * cX
         const Cy1 = parseInt(multiSapeAry[k].cubBzPt[0].y) * cY
@@ -172,7 +172,7 @@ export function getCustomShapePath(custShapType, w, h) {
         const Cx3 = parseInt(multiSapeAry[k].cubBzPt[2].x) * cX
         const Cy3 = parseInt(multiSapeAry[k].cubBzPt[2].y) * cY
         d += ' C' + Cx1 + ',' + Cy1 + ' ' + Cx2 + ',' + Cy2 + ' ' + Cx3 + ',' + Cy3
-      } 
+      }
       else if (multiSapeAry[k].type === 'arcTo') {
         const hR = parseInt(multiSapeAry[k].hR) * cX
         const wR = parseInt(multiSapeAry[k].wR) * cY

--- a/src/shapePath.js
+++ b/src/shapePath.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 
-import { RATIO_EMUs_Points } from './constants'
-import { getTextByPathList } from './utils'
+import { RATIO_EMUs_Points } from './constants.js'
+import { getTextByPathList } from './utils.js'
 
 function shapePie(H, w, adj1, adj2, isClose) {
   const pieVal = parseInt(adj2)
@@ -20,7 +20,7 @@ function shapePie(H, w, adj1, adj2, isClose) {
   if (isClose) {
     longArc = (value <= 180) ? 0 : 1
     d = `M${radius},${radius} L${radius},0 A${radius},${radius} 0 ${longArc},1 ${radius + y * radius},${radius - x * radius} z`
-  } 
+  }
   else {
     longArc = (value <= 180) ? 0 : 1
     const radius1 = radius
@@ -54,7 +54,7 @@ function shapeGear(h, points) {
     if (toggle) {
       d += ' L' + (cx + radiusI * Math.cos(a - taperAI)) + ',' + (cy + radiusI * Math.sin(a - taperAI))
       d += ' L' + (cx + radiusO * Math.cos(a + taperAO)) + ',' + (cy + radiusO * Math.sin(a + taperAO))
-    } 
+    }
     else {
       d += ' L' + (cx + radiusO * Math.cos(a - taperAO)) + ',' + (cy + radiusO * Math.sin(a - taperAO))
       d += ' L' + (cx + radiusI * Math.cos(a + taperAI)) + ',' + (cy + radiusI * Math.sin(a + taperAI))
@@ -123,7 +123,7 @@ function shapeSnipRoundRect(w, h, adj1, adj2, shapeType, adjType) {
 
   if (shapeType === 'round') {
     return `M0,${h / 2 + (1 - adjB) * (h / 2)} Q0,${h} ${adjB * (w / 2)},${h} L${w / 2 + (1 - adjC) * (w / 2)},${h} Q${w},${h} ${w},${h / 2 + (h / 2) * (1 - adjC)} L${w},${(h / 2) * adjD} Q${w},0 ${w / 2 + (w / 2) * (1 - adjD)},0 L${(w / 2) * adjA},0 Q0,0 0,${(h / 2) * (adjA)} z`
-  } 
+  }
   else if (shapeType === 'snip') {
     return `M0,${adjA * (h / 2)} L0,${h / 2 + (h / 2) * (1 - adjB)} L${adjB * (w / 2)},${h} L${w / 2 + (w / 2) * (1 - adjC)},${h} L${w},${h / 2 + (h / 2) * (1 - adjC)} L${w},${adjD * (h / 2)} L${w / 2 + (w / 2) * (1 - adjD)},0 L${(w / 2) * adjA},0 z`
   }
@@ -542,7 +542,7 @@ export function getShapePath(shapType, w, h, node) {
 
         if (shapType === 'flowChartOr') {
           pathData += ` M ${w / 2} 0 L ${w / 2} ${h} M 0 ${h / 2} L ${w} ${h / 2}`
-        } 
+        }
         else if (shapType === 'flowChartSummingJunction') {
           const angVal = Math.PI / 4
           const iDx = (w / 2) * Math.cos(angVal)
@@ -575,13 +575,13 @@ export function getShapePath(shapType, w, h, node) {
             if (sAdj_name === 'adj1') {
               const sAdj1 = getTextByPathList(adj, ['attrs', 'fmla'])
               sAdj1_val = parseInt(sAdj1.substring(4)) / 50000
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               const sAdj2 = getTextByPathList(adj, ['attrs', 'fmla'])
               sAdj2_val = parseInt(sAdj2.substring(4)) / 50000
             }
           }
-        } 
+        }
         else if (shapAdjst_ary) {
           const sAdj = getTextByPathList(shapAdjst_ary, ['attrs', 'fmla'])
           sAdj1_val = parseInt(sAdj.substring(4)) / 50000
@@ -664,7 +664,7 @@ export function getShapePath(shapType, w, h, node) {
             if (sAdj_name === 'adj1') {
               const sAdj1 = getTextByPathList(adj, ['attrs', 'fmla'])
               sAdj1_val = parseInt(sAdj1.substring(4)) / 50000
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               const sAdj2 = getTextByPathList(adj, ['attrs', 'fmla'])
               sAdj2_val = parseInt(sAdj2.substring(4)) / 50000
@@ -699,8 +699,8 @@ export function getShapePath(shapType, w, h, node) {
 
         if (shapType === 'flowChartMerge') {
           [p1x, p1y] = [w - p1x, h - p1y]
-          ;[p2x, p2y] = [w - p2x, h - p2y]
-          ;[p3x, p3y] = [w - p3x, h - p3y]
+            ;[p2x, p2y] = [w - p2x, h - p2y]
+            ;[p3x, p3y] = [w - p3x, h - p3y]
         }
 
         pathData = `M ${p1x} ${p1y} L ${p2x} ${p2y} L ${p3x} ${p3y} Z`
@@ -744,9 +744,9 @@ export function getShapePath(shapType, w, h, node) {
 
         if (shapType === 'flowChartManualOperation') {
           [p1x, p1y] = [w - p1x, h - p1y]
-          ;[p2x, p2y] = [w - p2x, h - p2y]
-          ;[p3x, p3y] = [w - p3x, h - p3y]
-          ;[p4x, p4y] = [w - p4x, h - p4y]
+            ;[p2x, p2y] = [w - p2x, h - p2y]
+            ;[p3x, p3y] = [w - p3x, h - p3y]
+            ;[p4x, p4y] = [w - p4x, h - p4y]
         }
 
         pathData = `M ${p1x} ${p1y} L ${p2x} ${p2y} L ${p3x} ${p3y} L ${p4x} ${p4y} Z`
@@ -858,10 +858,10 @@ export function getShapePath(shapType, w, h, node) {
             const name = shapAdjst[key]['attrs']['name']
             if (name === 'adj') {
               adj = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (name === 'hf') {
               hf = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (name === 'vf') {
               vf = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
             }
@@ -914,7 +914,7 @@ export function getShapePath(shapType, w, h, node) {
             const name = shapAdjst[key]['attrs']['name']
             if (name === 'adj') {
               adj = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (name === 'hf') {
               hf = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
             }
@@ -956,10 +956,10 @@ export function getShapePath(shapType, w, h, node) {
             const name = shapAdjst[key]['attrs']['name']
             if (name === 'adj') {
               adj = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (name === 'hf') {
               hf = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (name === 'vf') {
               vf = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
             }
@@ -1060,7 +1060,7 @@ export function getShapePath(shapType, w, h, node) {
             const name = shapAdjst[key]['attrs']['name']
             if (name === 'adj') {
               adj = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (name === 'hf') {
               hf = parseInt(shapAdjst[key]['attrs']['fmla'].substring(4)) * RATIO_EMUs_Points
             }
@@ -1423,13 +1423,13 @@ export function getShapePath(shapType, w, h, node) {
           adj2 = 270
           H = h
           isClose = true
-        } 
+        }
         else if (shapType === 'pieWedge') {
           adj1 = 180
           adj2 = 270
           H = 2 * h
           isClose = true
-        } 
+        }
         else if (shapType === 'arc') {
           adj1 = 270
           adj2 = 0
@@ -1466,7 +1466,7 @@ export function getShapePath(shapType, w, h, node) {
             if (sAdj_name === 'adj1') {
               const sAdj1 = getTextByPathList(adj, ['attrs', 'fmla'])
               sAdj1_val = parseInt(sAdj1.substring(4)) / 60000
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               const sAdj2 = getTextByPathList(adj, ['attrs', 'fmla'])
               sAdj2_val = parseInt(sAdj2.substring(4)) / 60000
@@ -1565,7 +1565,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               sAdj1_val = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               sAdj2_val = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -1597,10 +1597,10 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 60000
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 60000
-            } 
+            }
             else if (sAdj_name === 'adj3') {
               adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -1630,7 +1630,7 @@ export function getShapePath(shapType, w, h, node) {
           const dy1 = hd2 * (Math.sin(Math.atan(ht1 / wt1)))
           x1 = hc - dx1
           y1 = vc - dy1
-        } 
+        }
         else {
           const wt1 = wd2 * (Math.sin(stRd))
           const ht1 = hd2 * (Math.cos(stRd))
@@ -1650,7 +1650,7 @@ export function getShapePath(shapType, w, h, node) {
           const dy2 = ihd2 * (Math.sin(Math.atan(wt2 / ht2)))
           x2 = hc + dx2
           y2 = vc + dy2
-        } 
+        }
         else {
           const wt2 = iwd2 * (Math.sin((Math.PI) / 2 - istRd))
           const ht2 = ihd2 * (Math.cos((Math.PI) / 2 - istRd))
@@ -1699,7 +1699,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -1733,7 +1733,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -1841,7 +1841,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               sAdj1_val = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               sAdj2_val = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -2171,7 +2171,7 @@ export function getShapePath(shapType, w, h, node) {
               const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
               if (sAdj_name === 'adj1') {
                 adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
-              } 
+              }
               else if (sAdj_name === 'adj2') {
                 adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
               }
@@ -2278,7 +2278,7 @@ export function getShapePath(shapType, w, h, node) {
           const y3 = b - ch
           const y4 = b - ch2
           pathData = `M ${ch},${y3} L ${ch},${ch2} ${shapeArc(x3, ch2, ch2, ch2, 180, 270, false).replace('M', 'L')} L ${x7},${t} ${shapeArc(x7, ch2, ch2, ch2, 270, 450, false).replace('M', 'L')} L ${x6},${ch} L ${x6},${y4} ${shapeArc(x5, y4, ch2, ch2, 0, 90, false).replace('M', 'L')} L ${ch2},${b} ${shapeArc(ch2, y4, ch2, ch2, 90, 270, false).replace('M', 'L')} z M ${x3},${t} ${shapeArc(x3, ch2, ch2, ch2, 270, 450, false).replace('M', 'L')} ${shapeArc(x3, x3 / 2, ch4, ch4, 90, 270, false).replace('M', 'L')} L ${x4},${ch2} M ${x6},${ch} L ${x3},${ch} M ${ch},${y4} ${shapeArc(ch2, y4, ch2, ch2, 0, 270, false).replace('M', 'L')} ${shapeArc(ch2, (y4 + y3) / 2, ch4, ch4, 270, 450, false).replace('M', 'L')} z M ${ch},${y4} L ${ch},${y3}`
-        } 
+        }
         else if (shapType === 'horizontalScroll') {
           const y3 = ch + ch2
           const y4 = ch + ch
@@ -2302,7 +2302,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
             }
@@ -2341,7 +2341,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
             }
@@ -2387,10 +2387,10 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
-            } 
+            }
             else if (sAdj_name === 'adj3') {
               adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
             }
@@ -2608,10 +2608,10 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
-            } 
+            }
             else if (sAdj_name === 'adj3') {
               adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
             }
@@ -2659,7 +2659,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -2701,7 +2701,7 @@ export function getShapePath(shapType, w, h, node) {
           const y6 = b - hR
           const y7 = y1 - hR
           pathData = `M ${l},${b} L ${wd8},${y3} L ${l},${y4} L ${x2},${y4} L ${x2},${hR} ${shapeArc(x3, hR, wd32, hR, 180, 270, false).replace('M', 'L')} L ${x8},${t} ${shapeArc(x8, hR, wd32, hR, 270, 360, false).replace('M', 'L')} L ${x9},${y4} L ${r},${y4} L ${x10},${y3} L ${r},${b} L ${x7},${b} ${shapeArc(x7, y6, wd32, hR, 90, 270, false).replace('M', 'L')} L ${x8},${y1} ${shapeArc(x8, y7, wd32, hR, 90, -90, false).replace('M', 'L')} L ${x3},${y2} ${shapeArc(x3, y7, wd32, hR, 270, 90, false).replace('M', 'L')} L ${x4},${y1} ${shapeArc(x4, y6, wd32, hR, 270, 450, false).replace('M', 'L')} z M ${x5},${y2} L ${x5},${y6} M ${x6},${y6} L ${x6},${y2} M ${x2},${y7} L ${x2},${y4} M ${x9},${y4} L ${x9},${y7}`
-        } 
+        }
         else if (shapType === 'ribbon') {
           const y1 = h * a1 / cnstVal5
           const y2 = h * a1 / cnstVal4
@@ -2724,7 +2724,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -2767,7 +2767,7 @@ export function getShapePath(shapType, w, h, node) {
           const x13 = x12 + dx3
           const x14 = (x13 + x15) / 2
           pathData = `M ${x2},${y1} C ${x3},${y2} ${x4},${y3} ${x5},${y1} C ${x6},${y2} ${x7},${y3} ${x8},${y1} L ${x15},${y4} C ${x14},${y6} ${x13},${y5} ${x12},${y4} C ${x11},${y6} ${x10},${y5} ${x9},${y4} z`
-        } 
+        }
         else if (shapType === 'wave') {
           const cnstVal5 = 20000 * RATIO_EMUs_Points
           const a1 = (adj1 < 0) ? 0 : (adj1 > cnstVal5) ? cnstVal5 : adj1
@@ -2807,10 +2807,10 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj3') {
               adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -2864,7 +2864,7 @@ export function getShapePath(shapType, w, h, node) {
           const cy6 = cy3 + rh
           const y7 = y1 + dy3
           pathData = `M ${l},${t} Q ${cx1},${cy1} ${x3},${y1} L ${x2},${y3} Q ${hc},${cy3} ${x5},${y3} L ${x4},${y1} Q ${cx2},${cy1} ${r},${t} L ${x6},${y2} L ${r},${rh} Q ${cx5},${cy4} ${x5},${y5} L ${x5},${y6} Q ${hc},${cy6} ${x2},${y6} L ${x2},${y5} Q ${cx4},${cy4} ${l},${rh} L ${wd8},${y2} z M ${x2},${y5} L ${x2},${y3} M ${x5},${y3} L ${x5},${y5} M ${x3},${y1} L ${x3},${y7} M ${x4},${y7} L ${x4},${y1}`
-        } 
+        }
         else if (shapType === 'ellipseRibbon2') {
           const u1 = f1 * q2
           const y1 = b - u1
@@ -2912,7 +2912,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               sAdj1_val = 0.5 - (parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 200000)
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               const sAdj2_val2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 100000
               sAdj2_val = 1 - (sAdj2_val2 / max_sAdj2_const)
@@ -2933,7 +2933,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               sAdj1_val = 0.5 - (parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 200000)
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               const sAdj2_val2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 100000
               sAdj2_val = sAdj2_val2 / max_sAdj2_const
@@ -2955,7 +2955,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               sAdj1_val = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 200000
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               const sAdj2_val2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 100000
               sAdj2_val = sAdj2_val2 / max_sAdj2_const
@@ -2980,7 +2980,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               sAdj1_val = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 200000
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               const sAdj2_val2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 100000
               sAdj2_val = sAdj2_val2 / max_sAdj2_const
@@ -3001,7 +3001,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               sAdj1_val = 0.5 - (parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 200000)
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               const sAdj2_val2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 100000
               sAdj2_val = sAdj2_val2 / max_sAdj2_const
@@ -3022,7 +3022,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               sAdj1_val = 0.5 - (parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 200000)
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               const sAdj2_val2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) / 100000
               sAdj2_val = sAdj2_val2 / max_sAdj2_const
@@ -3046,10 +3046,10 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj3') {
               adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -3094,10 +3094,10 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj3') {
               adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -3141,10 +3141,10 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj3') {
               adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -3185,10 +3185,10 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj3') {
               adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -3225,13 +3225,13 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj3') {
               adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj4') {
               adj4 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -3342,7 +3342,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -3377,7 +3377,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * RATIO_EMUs_Points
             }
@@ -4047,7 +4047,7 @@ export function getShapePath(shapType, w, h, node) {
                 adj3 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4))
               }
             }
-          } 
+          }
           else {
             adj1 = parseInt(getTextByPathList(shapAdjst_ary, ['attrs', 'fmla']).substring(4))
           }
@@ -4112,7 +4112,7 @@ export function getShapePath(shapType, w, h, node) {
           const dly = h - ry
           const dry = h - ly
           pathData = `M ${x1},${y1} L ${x6},${y1} L ${lx},${ly} L ${rx},${ry} L ${rx6},${y1} L ${x8},${y1} L ${x8},${y2} L ${rx5},${y2} L ${rx4},${y3} L ${x8},${y3} L ${x8},${y4} L ${rx3},${y4} L ${drx},${dry} L ${dlx},${dly} L ${x3},${y4} L ${x1},${y4} L ${x1},${y3} L ${x4},${y3} L ${x5},${y2} L ${x1},${y2} z`
-        } 
+        }
         else if (shapType === 'mathDivide') {
           if (adj1 === undefined) adj1 = 23520
           if (adj2 === undefined) adj2 = 5880
@@ -4142,7 +4142,7 @@ export function getShapePath(shapType, w, h, node) {
           const x1 = hc - dx1
           const x3 = hc + dx1
           pathData = `M ${hc},${y1} A ${rad},${rad} 0 1,0 ${hc},${y1 + 2 * rad} A ${rad},${rad} 0 1,0 ${hc},${y1} z M ${hc},${y5} A ${rad},${rad} 0 1,1 ${hc},${y5 - 2 * rad} A ${rad},${rad} 0 1,1 ${hc},${y5} z M ${x1},${y3} L ${x3},${y3} L ${x3},${y4} L ${x1},${y4} z`
-        } 
+        }
         else if (shapType === 'mathEqual') {
           if (adj1 === undefined) adj1 = 23520
           if (adj2 === undefined) adj2 = 11760
@@ -4163,7 +4163,7 @@ export function getShapePath(shapType, w, h, node) {
           const x1 = hc - dx1
           const x2 = hc + dx1
           pathData = `M ${x1},${y1} L ${x2},${y1} L ${x2},${y2} L ${x1},${y2} z M ${x1},${y3} L ${x2},${y3} L ${x2},${y4} L ${x1},${y4} z`
-        } 
+        }
         else if (shapType === 'mathMinus') {
           if (adj1 === undefined) adj1 = 23520
           adj1 *= RATIO_EMUs_Points
@@ -4176,7 +4176,7 @@ export function getShapePath(shapType, w, h, node) {
           const x1 = hc - dx1
           const x2 = hc + dx1
           pathData = `M ${x1},${y1} L ${x2},${y1} L ${x2},${y2} L ${x1},${y2} z`
-        } 
+        }
         else if (shapType === 'mathMultiply') {
           if (adj1 === undefined) adj1 = 23520
           adj1 *= RATIO_EMUs_Points
@@ -4207,7 +4207,7 @@ export function getShapePath(shapType, w, h, node) {
           const yH = h - yB
           const yI = h - yC
           pathData = `M ${xA},${yA} L ${xB},${yB} L ${hc},${yC} L ${xD},${yB} L ${xE},${yA} L ${xF},${vc} L ${xE},${yG} L ${xD},${yH} L ${hc},${yI} L ${xB},${yH} L ${xA},${yG} L ${xL},${vc} z`
-        } 
+        }
         else if (shapType === 'mathPlus') {
           if (adj1 === undefined) adj1 = 23520
           adj1 *= RATIO_EMUs_Points
@@ -4279,7 +4279,7 @@ export function getShapePath(shapType, w, h, node) {
             const sAdj_name = getTextByPathList(adj, ['attrs', 'name'])
             if (sAdj_name === 'adj1') {
               adj1 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
-            } 
+            }
             else if (sAdj_name === 'adj2') {
               adj2 = parseInt(getTextByPathList(adj, ['attrs', 'fmla']).substring(4)) * refr
             }

--- a/src/table.js
+++ b/src/table.js
@@ -1,6 +1,6 @@
-import { getShapeFill, getSolidFill } from './fill'
-import { getTextByPathList } from './utils'
-import { getBorder } from './border'
+import { getShapeFill, getSolidFill } from './fill.js'
+import { getTextByPathList } from './utils.js'
+import { getBorder } from './border.js'
 
 export function getTableBorders(node, warpObj) {
   const borders = {}
@@ -58,7 +58,7 @@ export async function getTableCellParams(tcNode, thisTblStyle, cellSource, warpO
     const fill = await getShapeFill(cellObj, undefined, false, warpObj, 'slide')
 
     if (fill && fill.type === 'color' && fill.value) {
-      fillColor = fill.value 
+      fillColor = fill.value
     }
   }
   if (!fillColor) {

--- a/src/text.js
+++ b/src/text.js
@@ -1,5 +1,5 @@
-import { getHorizontalAlign } from './align'
-import { getTextByPathList } from './utils'
+import { getHorizontalAlign } from './align.js'
+import { getTextByPathList } from './utils.js'
 
 import {
   getFontType,
@@ -40,7 +40,7 @@ export function genTextBody(textBodyNode, spNode, slideLayoutSpNode, type, warpO
       if (brNode) {
         brNode = (brNode.constructor === Array) ? brNode : [brNode]
         brNode.forEach(item => item.type = 'br')
-  
+
         if (brNode.length > 1) brNode.shift()
         rNode = rNode.concat(brNode)
         rNode.sort((a, b) => {
@@ -72,7 +72,7 @@ export function genTextBody(textBodyNode, spNode, slideLayoutSpNode, type, warpO
       }
       text += `<p style="text-align: ${align};">`
     }
-    
+
     if (!rNode) text += genSpanElement(pNode, spNode, textBodyNode, pFontStyle, slideLayoutSpNode, type, warpObj)
     else {
       for (const rNodeItem of rNode) {
@@ -92,7 +92,7 @@ export function getListType(node) {
 
   if (pPrNode['a:buChar']) return 'ul'
   if (pPrNode['a:buAutoNum']) return 'ol'
-  
+
   return ''
 }
 
@@ -136,6 +136,6 @@ export function genSpanElement(node, pNode, textBodyNode, pFontStyle, slideLayou
   if (linkID) {
     const linkURL = warpObj['slideResObj'][linkID]['target']
     return `<span style="${styleText}"><a href="${linkURL}" target="_blank">${text.replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;').replace(/\s/g, '&nbsp;')}</a></span>`
-  } 
+  }
   return `<span style="${styleText}">${text.replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;').replace(/\s/g, '&nbsp;')}</span>`
 }


### PR DESCRIPTION
> 在 ESM（import/export）模式下，Node.js 默认要求显式指定文件扩展名。

总会有人想把解析 pptx 工作放到 nodejs 编写的后端服务端中，nodejs 使用 import 就需要明确引入的文件后缀类型，否则就会报 `Error [ERR_MODULE_NOT_FOUND]`