### PR TITLE
fix: 图片无法正确解析的兜底方案

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
 export const RATIO_Inches_EMUs = 914400 // 1英寸 = 914400EMUs
 export const RATIO_Inches_Points = 72 // 1英寸 = 72pt
 export const RATIO_EMUs_Points = RATIO_Inches_Points / RATIO_Inches_EMUs // 1EMUs = (72 / 914400)pt
+export const BASE64_ERROR_IMG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=' // 缺省图片(1x1px)

--- a/src/fill.js
+++ b/src/fill.js
@@ -1,5 +1,6 @@
 import tinycolor from 'tinycolor2'
 import { getSchemeColorFromTheme } from './schemeColor'
+import { BASE64_ERROR_IMG } from './constants.js'
 import {
   applyShade,
   applyTint,
@@ -34,7 +35,14 @@ export function getFillType(node) {
 
 export async function getPicFill(type, node, warpObj) {
   let img
-  const rId = node['a:blip']['attrs']['r:embed']
+  let rId
+  try {
+    rId = node['a:blip']['attrs']['r:embed']
+  } catch (err) {
+    console.warn(err)
+    console.warn('Found an image fill that could not be parsed correctly.')
+    return BASE64_ERROR_IMG
+  }
   let imgPath
   if (type === 'slideBg' || type === 'slide') {
     imgPath = getTextByPathList(warpObj, ['slideResObj', rId, 'target'])


### PR DESCRIPTION
我在实际使用中，就是会遇到了某些图片元素无法正确解析的情况。
因为这一个小错误会导致整个 pptx 无法导入，所以我建议给 getPicFill() 函数增加兜底方案：若解析遇到错误则使用一个 1x1 像素的 base64 图片替换。

具体的经过如下：
我在导入某个 .pptx 文件时遇到报错，我把有错误元素单的 .pptx 独提取出来了：
https://github.com/puxiao/notes/blob/master/temp/pptxtojson_getPicFill_error.pptx

我定位到 pptxtojson.js 代码：
const blipFill = getTextByPathList(fallback, ['p:sp', 'p:spPr', 'a:blipFill'])
const picBase64 = await getPicFill(source, blipFill, warpObj)
其中某次 blipFill 得到的值为 undefine，因此导致后面 await getPicFill(source, blipFill, warpObj) 中报错。
我原本想修改成：const picBase64 = blipFill ? await getPicFill(source, blipFill, warpObj) : BASE64_ERROR_IMG
但是搜索了一下发现 fill.js 中也有 2 处使用到了 getPicFill 函数，所以，干脆直接修改 getPicFill 函数增加兜底处理。

