### PR TITLE
fix: 修复将 text 类型识别成 shape 类型

### DIFF
--- a/src/pptxtojson.js
+++ b/src/pptxtojson.js
@@ -549,6 +549,9 @@ async function processSpNode(node, pNode, warpObj, source) {
   if (!type) {
     const txBoxVal = getTextByPathList(node, ['p:nvSpPr', 'p:cNvSpPr', 'attrs', 'txBox'])
     if (txBoxVal === '1') type = 'text'
+
+    const hasTextBody = getTextByPathList(node, ['p:txBody']);
+    if (hasTextBody) type = 'text';
   }
   if (!type) type = getTextByPathList(slideLayoutSpNode, ['p:nvSpPr', 'p:nvPr', 'p:ph', 'attrs', 'type'])
   if (!type) type = getTextByPathList(slideMasterSpNode, ['p:nvSpPr', 'p:nvPr', 'p:ph', 'attrs', 'type'])


### PR DESCRIPTION
修复 PPTX 普通文本框识别问题

**问题：**
普通文本框在导出 JSON 时被误判为 shape（obj），导致
1.  导入 pptx 之后，点击原本是 text 类型的元素，右侧样式是属于 shape 类型的交互
2. 导出 pptx 之后，此时解析 pptx 进行导入，在旧版会出现黑块（目前版本已经修复），但是此时再次导出为 pptx，在 text 元素的位置上会插入黑块（插入了一张空白的图片，fill 默认为黑色）

**解决方案：**
- 在 processSpNode 中增加对普通文本框的判断：
  - 如果 node 内存在 `p:txBody` 节点，则识别为 type='text'
- 保留原有占位符文本和 txBox 判断逻辑
- 默认 obj 类型仍然保留，用于其他非文本 shape

**效果：**
- 占位符文本和普通文本框均可正确识别为文本
- 避免文本被误判为 shape 导致显示异常